### PR TITLE
[feature] optimize common configs and apply db schema isolation per service

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,18 @@
+#https://www.coderabbit.ai/blog/how-to-integrate-ai-code-review-into-your-devops-pipeline 을 참고하여 설정을 추가할 수 있습니다.
+
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: ko-KR
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  changed_files_summary: false
+  poem: false
+  review_status: true
+  review_details: false
+  auto_review:
+    enabled: true
+    drafts: true
+chat:
+  auto_reply: true

--- a/configs/common/application.yml
+++ b/configs/common/application.yml
@@ -1,49 +1,45 @@
 # common/application.yml
 
-eureka:
-  instance:
-    prefer-ip-address: true
-  client:
-    register-with-eureka: true
-    fetch-registry: true
-    service-url:
-      # Eureka 서버 주소도 환경 변수로 관리 (기본값은 localhost)
-      defaultZone: ${EUREKA_SERVER_URL:http://localhost:8761/eureka/}
+custom:
+  db:
+    host: ${POSTGRES_HOST:localhost}
+    port: ${POSTGRES_PORT:5432}
+    name: ${DB_NAME:da_it_da_db}
 
 spring:
-  # 1. PostgreSQL 설정
   datasource:
-    driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_PORT}/${DB_NAME}
-    username: ${DB_USERNAME}
+    # 각 서비스의 custom.db.schema 값을 받아 URL 조립
+    url: jdbc:postgresql://${custom.db.host}:${custom.db.port}/${custom.db.name}?currentSchema=${custom.db.schema}
+    username: ${DB_USERNAME:postgres_daitda}
     password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
 
-  # 2. Redis 설정
-  data:
-    redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
-
-  # 3. JPA/Hibernate 설정
   jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: update
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
+        default_schema: ${custom.db.schema}
         format_sql: true
 
-# 4. Zipkin (Tracing) 설정
-management:
-  tracing:
-    sampling:
-      probability: 1.0
-  zipkin:
-    tracing:
-      endpoint: http://${ZIPKIN_HOST:localhost}:${ZIPKIN_PORT:9411}/api/v2/spans
+eureka:
+  client:
+    register-with-eureka: true # 명시적으로 작성하여 가독성 확보
+    fetch-registry: true
+    service-url:
+      defaultZone: http://${EUREKA_HOST:localhost}:8761/eureka/
 
-# 5. Keycloak 설정
-keycloak:
-  auth-server-url: http://${KEYCLOAK_HOST:localhost}:${KEYCLOAK_PORT:9090}
-  admin-user: ${KC_ADMIN_USER}
-  admin-password: ${KC_ADMIN_PASSWORD}
+feign:
+  client:
+    config:
+      default:
+        connectTimeout: 5000
+        readTimeout: 5000
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: refresh,health,info,metrics

--- a/configs/common/application.yml
+++ b/configs/common/application.yml
@@ -5,6 +5,7 @@ custom:
     host: ${POSTGRES_HOST:localhost}
     port: ${POSTGRES_PORT:5432}
     name: ${DB_NAME:da_it_da_db}
+    # schema: 각 서비스에서 반드시 정의해야 함 (예: user_service)
 
 spring:
   datasource:

--- a/configs/user-service/user-service.yml
+++ b/configs/user-service/user-service.yml
@@ -1,13 +1,13 @@
 # user-service/user-service.yml
+custom:
+  db:
+    schema: user_service
+
 server:
   port: 8081
 
-# 서비스 고유의 비즈니스 설정 예시
-user-service:
-  message: "이 메시지는 Config Server의 user-service.yml에서 불러온 메시지입니다."
-  feature-x-enabled: true
-
-# 로그 레벨 개별 설정
-logging:
-  level:
-    com.example.userservice: DEBUG
+keycloak:
+  auth-server-url: http://${KEYCLOAK_HOST:localhost}:${KEYCLOAK_PORT:9090}
+  realm: ${KEYCLOAK_REALM:da-it-da-realm}
+  client-id: user-service-client
+  client-secret: ${KEYCLOAK_CLIENT_SECRET} # .env에서 주입됨


### PR DESCRIPTION
## 🌱 설명

서비스별로 독립된 DB 스키마를 사용하도록 구조를 개선했습니다. 
공통 설정의 중복을 제거하고, 환경 변수 주입 방식을 도입했습니다.

## 📌 관련 이슈

- close #3 

## ✅ 주요 변경 사항

- common config 수정 : 각 서비스에 필요한 설정 분리

- 변수 조립: common 설정에서 URL 틀을 제공하고, 각 서비스가 자신의 custom.db.schema 값을 주입하여 연결

- Hibernate 스키마 격리: default_schema 설정을 통해 각 서비스가 지정된 스키마(예: user_service) 외의 영역을 침범하지 않도록 설정

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

common config와 user-service config를 확인해주세요.
각 서비스에 필요한 설정은 따로 얘기해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **운영 개선**
  * 데이터베이스 연결 구성 재정비(스키마 지정 및 접속 정보 분리)
  * 클라이언트 타임아웃 및 관리 엔드포인트(리프레시/헬스/인포/메트릭) 설정 추가
  * 인증(Keycloak) 통합 설정 추가 및 로깅/불필요 추적 구성 정리

* **환경설정/도구**
  * 자동 리뷰 및 챗 자동응답 등을 포함한 개발 도구 구성 파일 추가(검토 동작·요약 자동화 등)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->